### PR TITLE
sets loading to false before the early return on fail

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -34,6 +34,7 @@ function App() {
     }
 
     const generatedSrc = await generateImage(prompt, dataURL);
+    setLoading(false);
     if (!generatedSrc) {
       toast(`Ah geez, something borked. Try again, it'll probably be faster!`);
       return;
@@ -41,7 +42,6 @@ function App() {
 
     setQRCodeDataURL(dataURL);
     setImgSrc(generatedSrc);
-    setLoading(false);
   }, [prompt, qrCodeValue]);
 
   const downloadQRCode = useCallback(async () => {


### PR DESCRIPTION
this was cheesing my gears because before, when we had backend errors, you couldn't click the button even after the failure toast. it's because the `loading` flag was still set, so i moved it up to right after the generatedSrc is returned from the await