### PR TITLE
💸💸 - keep more containers warm for longer

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -128,7 +128,7 @@ def generate_and_save(job_id: str, prompt: str, image: str):
     _set_status(job_id, JobStatus.COMPLETE)
 
 
-@stub.function(shared_volumes={RESULTS_DIR: results_volume}, keep_warm=1)
+@stub.function(shared_volumes={RESULTS_DIR: results_volume}, keep_warm=10, container_idle_timeout=60)
 @asgi_app()
 def api():
     api_backend = FastAPI(
@@ -270,6 +270,7 @@ class InferenceConfig:
     secret=Secret.from_name("huggingface"),
     cloud="aws",
     keep_warm=1,
+    container_idle_timeout=120,
 )
 class Model:
     config = InferenceConfig()


### PR DESCRIPTION
Modal only charges for actually used resources, so keeping a bunch of containers idle is cheap -- we're only paying for RAM, which is basically free ya know