### PR TITLE
make error toasts dynamic and limit wait time on front end

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -63,26 +63,38 @@ function App() {
       return;
     }
 
+    const handleGenerationFailure = (waitingTime: number) => {
+      const waitColdBoot = 60_000;  // typical waiting time when backend hits a cold boot
+      let message = "Ah geez, something borked. Try again.";
+      if (waitingTime >= waitColdBoot) {
+        message += " It'll probably be faster!";
+      }
+      toast(message);
+      setLoading(false);
+    };
+
     const jobID = await startGeneration(prompt, dataURL);
     if (!jobID) {
-      toast(`Ah geez, something borked. Try again, it'll probably be faster!`);
-      setLoading(false);
+      handleGenerationFailure(-1);
       return;
     }
     setJobID(jobID);
 
-    while (true) {
-      await wait(1000);
+    const start = Date.now();
+    let waitingTime = 0;
+    const maxWaiting = 300_000; // set defensively high, backend should timeout first
+    const pollInterval = 1_000;
+    while (waitingTime < maxWaiting) {
+      await wait(pollInterval);
       if (cancelledRef.current) {
         break;
       }
 
       const { status, result } = await pollGeneration(jobID);
+      waitingTime = Date.now() - start;
 
       if (status === `FAILED`) {
-        toast(
-          `Ah geez, something borked. Try again, it'll probably be faster!`
-        );
+        handleGenerationFailure(waitingTime);
         break;
       }
 
@@ -93,7 +105,7 @@ function App() {
       }
     }
 
-    setLoading(false);
+    handleGenerationFailure(waitingTime);
   }, [prompt, qrCodeValue]);
 
   const cancel = useCallback(async () => {


### PR DESCRIPTION
when we hit cold boots, the wait time is long, but then future generations "should" be faster for the next few minutes.

we want to reflect that in our error toast.

also, we can drop the `while (true)` by adding some logic for giving up on polling

considered putting that logic into `lib/qrcode` but decided it was too close to app-y UX logic to belong there -- e.g. it's 

maybe cleaner would be to have `pollGeneration` return a wait time or even return the elapsed time from the backend (call that a wait limit in a thin-client architecture, pun intended), but aint nobody got time for that