### PR TITLE
Pinning toml==0.10.2 in generator and api images, adding `create_if_true` to results volume

### DIFF
--- a/backend/api/common.py
+++ b/backend/api/common.py
@@ -27,6 +27,7 @@ image = modal.Image.debian_slim(python_version="3.10").pip_install(
     "wonderwords",
     "Pillow",
     "aiofiles==24.1.0",
+    "toml==0.10.2",
 )
 app = modal.App("qart", image=image, mounts=[toml_file_mount, assets_mount])
 

--- a/backend/api/common.py
+++ b/backend/api/common.py
@@ -19,7 +19,7 @@ assets_mount = modal.Mount.from_local_dir(
     local_path=here.parent / "assets", remote_path=ASSETS_DIR
 )
 
-results_volume = modal.Volume.from_name("qart-results-vol")
+results_volume = modal.Volume.from_name("qart-results-vol", create_if_missing=True)
 
 image = modal.Image.debian_slim(python_version="3.10").pip_install(
     "fastapi[standard]==0.115.5",

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,3 +1,4 @@
 modal==0.68.29
 fastapi[standard]==0.115.5
 pydantic>=2,<3
+toml==0.10.2


### PR DESCRIPTION
Remote needs toml, but it wasn't explicitly in the image. Possibly previously getting it from another dependency.
-Pinning toml==0.10.2 in generator and api images.

API was attempting to access a volume that doesn't exist for a new deployment.
- Adding `create_if_true` to results volume in `backend/api/common.py`.
