### PR TITLE
fix state mgmt in qart code download onClick

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -153,14 +153,15 @@ const generate = useCallback(async () => {
   }, [qrCodeDataURL]);
 
   const downloadQArtCode = useCallback(async () => {
-    if (!imgSrc) {
+    const dataUrl = recentComposites[mainCompositeIndex].image;
+    if (!dataUrl) {
       return;
     }
     await downloadImage({
-      url: imgSrc,
-      fileName: `image`,
+      url: dataUrl,
+      fileName: `qart-code`,
     });
-  }, [imgSrc]);
+  }, [mainCompositeIndex, recentComposites]);
 
   return (
     <Container>


### PR DESCRIPTION
I think I introduced this issue last night, but -- the `imgSrc` React State was getting set and not updated

I moved to using the index and array combo (`recentComposites` and `mainCompositeIndex`) that's used in the display of the other codes underneath the primary one. I suspect `imgSrc` may now be un-needed? And in general I think the state mgmt could be cleaner, let's discuss in our 1:1 tomorrow.