### PR TITLE
reduces the opacity of codes besides main

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -305,7 +305,7 @@ const generate = useCallback(async () => {
         className={`transition-transform rounded-md ${
           idx === mainCompositeIndex
             ? "scale-105"
-            : "opacity-80 hover:opacity-100"
+            : "opacity-40 hover:opacity-100"
         }`}
       >
         <img


### PR DESCRIPTION
our QArt codes are _just too scannable_!

when we display multiple codes, scanners frequently end up jumping between them, not sure which one the user intends to scan.

even worse -- smaller qart codes actually scan better (unlike with normal qr codes). seems like the same "blurring" effect that makes the images look more like QR codes to humans when they are smaller also applies to smartphones!

so in this PR, I drop the opacity of non-focused codes. 40% was still nicely visible/subtle (IMO, see screenshot below) without triggering the detector. don't expect this to be too sensitive to prompt and it's a nice-to-have, so not being scientific about it.

![Screenshot 2025-06-26 at 4 53 14 PM](https://github.com/user-attachments/assets/94e8d873-361c-4981-9153-33c20f7ad082)
