### PR TITLE
add more sample prompts, pour encourager les autres

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,8 +2,10 @@ import { useCallback, useState, useRef, useEffect } from "react";
 import { toast } from "react-toastify";
 import { CompositeImage } from "./lib/components/CompositeImage";
 import { Loader } from "./lib/components/Loader";
+import { PromptSuggestions } from "./lib/components/PromptSuggestions";
 import { createDivContainer } from "./lib/components/helpers";
 import { downloadImage } from "./lib/download";
+import { getRandomPrompts } from "./lib/prompts";
 import {
   cancelGeneration,
   startGeneration,
@@ -39,6 +41,8 @@ function App() {
 	const [recentComposites, setRecentComposites] = useState<
   { qrCode: string; image: string }[]
 >([]);
+
+  const [displayedPrompts] = useState(() => getRandomPrompts(6));
 
 const generate = useCallback(async () => {
   if (!prompt) {
@@ -249,6 +253,10 @@ const generate = useCallback(async () => {
         placeholder="Visual content or style to apply to the QR code"
         value={prompt}
         onChange={(e) => setPrompt(e.target.value)}
+      />
+      <PromptSuggestions
+        prompts={displayedPrompts}
+        onPromptSelect={setPrompt}
       />
     </div>
 

--- a/src/lib/components/PromptSuggestions.tsx
+++ b/src/lib/components/PromptSuggestions.tsx
@@ -1,0 +1,44 @@
+import { FC } from "react";
+
+interface PromptChipProps {
+  text: string;
+  onClick: (text: string) => void;
+}
+
+const PromptChip: FC<PromptChipProps> = ({ text, onClick }) => (
+    <button
+      onClick={() => onClick(text)}
+      className="
+        px-4 py-2 rounded-full
+        bg-green-light/10 text-green-light/70
+        text-xs font-inter
+        hover:bg-green-light/20 hover:text-green-light
+        transition-colors border border-green-light/20
+        max-w-[200px] truncate
+        flex-shrink-0
+      "
+      title={text}
+    >
+      {text}
+    </button>
+  );
+
+interface PromptSuggestionsProps {
+  prompts: string[];
+  onPromptSelect: (prompt: string) => void;
+}
+
+export const PromptSuggestions: FC<PromptSuggestionsProps> = ({
+    prompts,
+    onPromptSelect
+  }) => (
+    <div className="flex flex-wrap gap-2 mt-3">
+      {prompts.map((prompt, idx) => (
+        <PromptChip
+          key={idx}
+          text={prompt}
+          onClick={onPromptSelect}
+        />
+      ))}
+    </div>
+  );

--- a/src/lib/prompts.ts
+++ b/src/lib/prompts.ts
@@ -1,0 +1,24 @@
+export const SAMPLE_PROMPTS = [
+    // // aim for an equal distribution across prompt types
+    // artist styles
+    "Cy Twombly",
+    "Mondrian",
+    "Sol LeWitt",
+    "Rauschenberg",
+    // comma-separated
+    "Penguins have a picnic on the savannah, beautiful landscape, sharp focus, masterpiece, 8k, intricate artwork, nature photography, hyper detailed, highly detailed, HD, 4K",
+    "neon green cubes, rendered in blender, trending on artstation, deep colors, cyberpunk aesthetic, striking contrast, hyperrealistic",
+    "crystalline structures, volumetric lighting, rendered in octane, photorealistic textures, prismatic reflections, studio lighting setup",
+    "paper cut art style, layered shadows, pastel color palette, handcrafted textures, stop motion animation feel, soft ambient lighting",
+    // ekphrasis (prose description)
+    "An abstract art piece inspired by dense forest foliage, featuring intricate patterns of leaves, branches, and flowers in vibrant shades of green, yellow, and gold. The design includes layered textures and soft gradients to create depth and a harmonious balance of details, illuminated by scattered rays of sunlight filtering through a canopy.",
+    "A dense jungle scene filled with towering trees, intertwining vines, and an abundance of foliage. The composition features detailed textures of leaves, moss, and bark, with sunlight streaming through the canopy to create dappled light patterns on the forest floor.",
+    "A surreal underwater coral reef filled with intricate details of colorful corals, seaweed, and marine life. The scene features vibrant fish, glowing bioluminescent plants, and rich textures, with light filtering from the water's surface creating soft, scattered patterns.",
+    "A lush, densely packed bouquet of flowers featuring a variety of species in full bloom. The flowers display intricate petal textures and patterns in a vibrant mix of colors, with soft shadows and subtle gradients creating depth and harmony.",
+    "A whimsical forest scene with fantastical trees, glowing mushrooms, and colorful wildflowers. The image is rich in detail, with textured bark, intricate leaves, and scattered beams of light breaking through the trees, casting soft, glowing patterns on the ground.",
+  ];
+
+  export const getRandomPrompts = (count = 6) => {
+    const shuffled = [...SAMPLE_PROMPTS].sort(() => 0.5 - Math.random());
+    return shuffled.slice(0, count);
+  };


### PR DESCRIPTION
Adds a few sample prompts to the UI, so that there's more obviously something to do besides come up with your own or apply the single existing prompt to your link.

![Screenshot 2025-07-02 at 11 23 25 AM](https://github.com/user-attachments/assets/7c2692f7-290b-40d7-be63-157f34bc2f41)

This was mostly written by Claude Sonnet 4, since I'm pretty slow at frontend, but 1) I have tried it at a few resolutions and 2) I confirmed the main flows work (clicking pills and then generating, overwriting the prompt field after clicking a pill).